### PR TITLE
Update manifest for v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # BL5340PA Manifest
 
-This manifest repository contains the Laird Connectivity fork of the nRF Connect SDK [Version 2.3.0](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.3.0/nrf/getting_started.html) with support for the [BL5340PA](https://www.lairdconnect.com/wireless-modules/bluetooth-modules/bl5340pa-series-long-range-bluetooth-module).
+This manifest repository contains the Laird Connectivity fork of the nRF Connect SDK [Version 2.4.1](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.4.1/nrf/index.html) with support for the [BL5340PA](https://www.lairdconnect.com/wireless-modules/bluetooth-modules/bl5340pa-series-long-range-bluetooth-module).
 
 This fork adds support for the BL5340PA DVK board. It also adds a driver for the [nRF21540](https://www.nordicsemi.com/products/nrf21540#:~:text=The%20nRF21540%20is%20a%20'plug,power%20short%2Drange%20wireless%20solutions) Front-End Module  used by the BL5340PA. The driver limits the RF output power based on region and antenna type. This is required for compliance with regulatory requirements. The driver also handles errata with the IO of the FEM. The Laird Connectivity driver works alongside the Nordic MPSL FEM driver.
 
-In-tree Zephyr sample applications added by this fork:
+Out-of-Tree Zephyr sample applications added by this manifest (bl5340pa_samples folder):
 - sleepy advertiser
-
-In-tree Zephyr samples modified by this fork:
 - throughput
+
+## Known Issues
+
+- L2-209 - Power Table for Coded s=2 not being used by Nordic MPSL FEM driver. The s=8 table is being used. The RF power for s=8 is less than s=2. Therefore, the module is still RF compliant, albeit with a lower power output than what is allowed.
+
+- L2-221 - Central device is unable to connect to a peripheral using coded PHY when FEM is operating in GPIO+SPI mode. A hard fault occurs on the network processor of the nRF5340.
 
 ## Cloning Firmware
 
 > **WARNING:** On Windows do not clone into a starting folder path longer than 12 characters or else the firmware will not build.
 
-This is a Zephyr `west` manifest repository. To learn more about `west` see [here](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.3.0/zephyr/develop/west/index.html#west).
+This is a Zephyr `west` manifest repository. To learn more about `west` see [here](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.4.1/zephyr/develop/west/index.html#west).
 
 To clone this repository properly use the `west` tool. To install `west` you will first need Python3. It is recommended to use Python virtual environments.
 
@@ -35,15 +39,16 @@ west update
 ```
 ## Preparing to Build
 
-If this is your first time working with a Zephyr project on your computer you should follow the [Zephyr getting started guide](https://docs.zephyrproject.org/latest/getting_started/index.html#) to install all the tools.
+If this is your first time working with a Zephyr project on your computer you should follow the [nRF getting started guide](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.4.1/nrf/getting_started.html) to install all the tools.
 
-v0.15.2 of the Zephyr SDK is recommended for building the firmware.
+v0.16.0 of the Zephyr SDK is recommended for building the firmware.
 
 > **WARNING:** Before building the firmware, be sure to install all python dependencies with the following commands:
 
 ```
 pip3 install -r zephyr/scripts/requirements.txt
 pip3 install -r nrf/scripts/requirements.txt
+pip3 install -r bootloader/mcuboot/scripts/requirements.txt
 ```
 
 ## Custom Board Files
@@ -73,7 +78,9 @@ In the cpu application (cpuapp) device tree specification (DTS), the FEM pins mu
 
 ### FEM
 
-The mode pin of the nRF21540 FEM is grounded on the BL5340PA module and the SPI bus is currently not used by the driver. 
+The mode pin of the nRF21540 FEM is grounded on the BL5340PA module. 
+
+The FEM driver uses the SPI bus. For this reason, UART0 is not available on the network core.
 
 ```
 nrf_radio_fem: nrf21540_fem {
@@ -81,6 +88,7 @@ nrf_radio_fem: nrf21540_fem {
     rx-en-gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
     tx-en-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
     pdn-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+    spi-if = <&nrf_radio_fem_spi>;
     supply-voltage-mv = <3300>;
 };
 ```
@@ -115,4 +123,16 @@ lcz_fem: nrf21540_lcz_fem  {
     internal-antenna;
     power-table = <1>;
 };
+```
+
+The antenna type and region can also be specified on the command line or in the project configuration. These configurations must be applied to network application.
+
+Select internal antenna.
+```
+west build -p -b bl5340pa_dvk_cpuapp -- -Dhci_rpmsg_CONFIG_LCZ_FEM_INTERNAL_ANTENNA=y
+``
+
+Select CE configuration on BL5340PA.
+```
+west build -p -b bl5340pa_dvk_cpuapp -- -Dhci_rpmsg_CONFIG_LCZ_FEM_REGION=2
 ```

--- a/west.yml
+++ b/west.yml
@@ -8,10 +8,14 @@ manifest:
 
   # Please add items below based on alphabetical order.
   projects:
+    - name: bl5340pa_samples
+      path: bl5340pa_samples
+      revision: bl5340pa-ga2.0
+      remote: LairdCP
     # The Laird Connectivity (BL5340PA) fork of the nRF Connect SDK (NCS).
     - name: sdk-nrf
       path: nrf
-      revision: bl5340pa-ga1.1
+      revision: bl5340pa-ga2.0
       remote: LairdCP
       import:
         # Import /nrf/west.yml except for Zephyr which is done below
@@ -21,7 +25,7 @@ manifest:
     # The Laird Connectivity fork of the Zephyr RTOS fork used by NCS
     - name: sdk-zephyr
       path: zephyr
-      revision: bl5340pa-ga1.1
+      revision: bl5340pa-ga2.0
       remote: LairdCP
       import:
         # 


### PR DESCRIPTION
Rebase Laird Connectivity FEM driver and BL5340PA board
changes onto NCS 2.4.1.
L2-105, L2-170

Enable SPI mode for FEM.
Add CE driver.
Move modified sample applications out-of-tree.
L2-208

Signed-off-by: Andrew Hedin <andrew.hedin@lairdconnect.com>

